### PR TITLE
Fix: except right exception

### DIFF
--- a/spice/_extract.py
+++ b/spice/_extract.py
@@ -918,7 +918,7 @@ def _get_results(
             else:
                 raise Exception(as_json['error'])
             raise Exception(as_json['error'])
-    except requests.JSONDecodeError:
+    except json.JSONDecodeError:
         pass
     result = response.text
     df = _process_raw_table(result, types=types, all_types=all_types)


### PR DESCRIPTION
Hi, guy! Fix little bug, when I start the code I receive exception like:
```Traceback (most recent call last):
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/pydevd.py", line 1534, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/zzz/Library/Application Support/JetBrains/PyCharm2023.3/scratches/scratch1.py", line 46, in <module>
    main()
  File "/Users/zzz/Library/Application Support/JetBrains/PyCharm2023.3/scratches/scratch1.py", line 5, in main
    df = spice.query('''
  File "/Users/zzz/work/vvv/venv/lib/python3.8/site-packages/spice/_extract.py", line 240, in query
    df = _get_results(**execute_kwargs, **result_kwargs)
  File "/Users/zzz/work/vvv/venv/lib/python3.8/site-packages/spice/_extract.py", line 921, in _get_results
    except (requests.JSONDecodeError):
AttributeError: module 'requests' has no attribute 'JSONDecodeError'
```
